### PR TITLE
Feature/#19 사이드바 권한설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.59.0(react@19.1.0))
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -500,6 +503,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.11':
+    resolution: {integrity: sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2389,6 +2405,22 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-collapsible@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -8,6 +8,9 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
 import SITE_MAP from '@/constants/siteMap.constant';
 import {
@@ -20,6 +23,11 @@ import { ChevronUp } from 'lucide-react';
 import { supabase } from '@/utils/supabase';
 import { useNavigate } from 'react-router-dom';
 import { useUserStore } from '@/store/user.store';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 
 const NavItems = [
   {
@@ -29,20 +37,33 @@ const NavItems = [
   {
     title: '출퇴근 관리',
     url: SITE_MAP.ATTENDANCE,
+    authority: true,
   },
   {
     title: '연차 관리',
-    url: SITE_MAP.ATTENDANCE,
+    children: [
+      {
+        title: '연차 신청',
+        url: SITE_MAP.LEAVE_REQUEST,
+      },
+      {
+        title: '연차 승인',
+        url: SITE_MAP.LEAVE_APPROVAL,
+        authority: true,
+      },
+    ],
   },
   {
     title: '직원 관리',
     url: SITE_MAP.EMPLOYEES,
+    authority: true,
   },
 ];
 
 const AppSidebar = () => {
   const user = useUserStore((state) => state.user);
   const navigate = useNavigate();
+  const isNotAdmin = user.role !== 'admin';
 
   const onSignOut = async () => {
     try {
@@ -66,15 +87,48 @@ const AppSidebar = () => {
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {NavItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <a href={item.url}>
-                      <span>{item.title}</span>
-                    </a>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
+              {NavItems.map((item) => {
+                if (item.authority && isNotAdmin) return null;
+                return item.children ? (
+                  <Collapsible
+                    defaultOpen
+                    className="group/collapsible"
+                    key={item.title}
+                  >
+                    <SidebarMenuItem>
+                      <CollapsibleTrigger asChild>
+                        <SidebarMenuButton>
+                          <span>{item.title}</span>
+                        </SidebarMenuButton>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent>
+                        <SidebarMenuSub>
+                          {item.children.map((child) => {
+                            if (child.authority && isNotAdmin) return null;
+                            return (
+                              <SidebarMenuSubItem key={child.title}>
+                                <SidebarMenuSubButton asChild>
+                                  <a href={child.url}>
+                                    <span>{child.title}</span>
+                                  </a>
+                                </SidebarMenuSubButton>
+                              </SidebarMenuSubItem>
+                            );
+                          })}
+                        </SidebarMenuSub>
+                      </CollapsibleContent>
+                    </SidebarMenuItem>
+                  </Collapsible>
+                ) : (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild>
+                      <a href={item.url}>
+                        <span>{item.title}</span>
+                      </a>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,31 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/constants/siteMap.constant.ts
+++ b/src/constants/siteMap.constant.ts
@@ -5,7 +5,8 @@ const SITE_MAP = {
   DASHBOARD: '/dashboard',
   EMPLOYEES: '/employees',
   ATTENDANCE: '/attendance',
-  LEAVE: '/leave',
+  LEAVE_REQUEST: 'leave-request',
+  LEAVE_APPROVAL: 'leave-approval',
 };
 
 export default SITE_MAP;

--- a/src/constants/siteMap.constant.ts
+++ b/src/constants/siteMap.constant.ts
@@ -5,8 +5,8 @@ const SITE_MAP = {
   DASHBOARD: '/dashboard',
   EMPLOYEES: '/employees',
   ATTENDANCE: '/attendance',
-  LEAVE_REQUEST: 'leave-request',
-  LEAVE_APPROVAL: 'leave-approval',
+  LEAVE_REQUEST: '/leave-request',
+  LEAVE_APPROVAL: '/leave-approval',
 };
 
 export default SITE_MAP;

--- a/src/pages/LeaveApprovalPage.tsx
+++ b/src/pages/LeaveApprovalPage.tsx
@@ -1,0 +1,5 @@
+const LeaveApprovalPage = () => {
+  return <div>LeaveApprovalPage</div>;
+};
+
+export default LeaveApprovalPage;

--- a/src/pages/LeavePage.tsx
+++ b/src/pages/LeavePage.tsx
@@ -1,9 +1,0 @@
-import { useGetLeaveTypesQuery } from '@/hooks/useLeaveTypesQuery';
-
-const LeavePage = () => {
-  const { data } = useGetLeaveTypesQuery();
-  console.log(data);
-  return <div>LeavePage</div>;
-};
-
-export default LeavePage;

--- a/src/pages/LeaveRequestPage.tsx
+++ b/src/pages/LeaveRequestPage.tsx
@@ -1,0 +1,5 @@
+const LeaveRequestPage = () => {
+  return <div>LeaveRequestPage</div>;
+};
+
+export default LeaveRequestPage;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -41,7 +41,7 @@ const router = createBrowserRouter([
       {
         path: SITE_MAP.ATTENDANCE,
         element: (
-          <ProtectedRoute roles={['employee']}>
+          <ProtectedRoute roles={['admin']}>
             <AttendancePage />
           </ProtectedRoute>
         ),

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -2,7 +2,6 @@ import MainLayout from '@/components/layouts/MainLayout';
 import AttendancePage from '@/pages/AttendancePage';
 import DashboardPage from '@/pages/DashboardPage';
 import EmployeesPage from '@/pages/Employees';
-import LeavePage from '@/pages/LeavePage';
 import LoginPage from '@/pages/LoginPage';
 import RegisterPage from '@/pages/RegisterPage';
 import {
@@ -12,6 +11,8 @@ import {
 } from 'react-router-dom';
 import ProtectedRoute from '@/routes/ProtectedRoute';
 import SITE_MAP from '@/constants/siteMap.constant';
+import LeaveRequestPage from '@/pages/LeaveRequestPage';
+import LeaveApprovalPage from '@/pages/LeaveApprovalPage';
 
 const router = createBrowserRouter([
   {
@@ -46,10 +47,18 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: SITE_MAP.LEAVE,
+        path: SITE_MAP.LEAVE_REQUEST,
         element: (
           <ProtectedRoute roles={['admin', 'employee']}>
-            <LeavePage />
+            <LeaveRequestPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: SITE_MAP.LEAVE_APPROVAL,
+        element: (
+          <ProtectedRoute roles={['admin']}>
+            <LeaveApprovalPage />
           </ProtectedRoute>
         ),
       },


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #19 
- 
<br>

## 📝 작업 내용

- 기존 LeavePage로 통합되어있던 연차 관리 페이지를 연차 승인(`LeaveApprovalPage`)와 연차 신청(`LeaveRequestPage`)로 분할
- 페이지 분할에 따른 라우팅 설정
- 메뉴별 `authority` key 부여, 사이드바에서 권한에 따라 메뉴가 노출/미노출 될 수 있도록 처리
- 메뉴별 `children` key로 하위 메뉴가 생성되도록 구현
- `Collapsible` Component를 사용해 서브메뉴가 열리고 닫히도록 구현

<br>

## 🖼 스크린샷
|직원 화면|관리자 화면|
|---|---|
|![image](https://github.com/user-attachments/assets/b5d652b2-1f0c-4745-877c-364b810e3613)|![image](https://github.com/user-attachments/assets/6701a789-2f4a-49fa-af26-b05158feb68e)|

<br>

## 💬리뷰 요구사항

> 없습니다!
