### PR TITLE
Feature/#27 관리자 연차 승인

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.59.0(react@19.1.0))
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.2
+        version: 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -506,6 +509,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.2':
+    resolution: {integrity: sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2433,6 +2449,22 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/src/apis/leaveRequests.api.ts
+++ b/src/apis/leaveRequests.api.ts
@@ -79,7 +79,7 @@ export const getLeaveRequests = async (): Promise<LeaveApprovals> => {
  *
  * @throws {Error} 데이터베이스 업데이트 실패 시 Supabase 에러를 던집니다
  */
-export const updateLeaveRequestStatus = async (
+export const patchLeaveRequestStatus = async (
   requestId: number | number[],
   status: 'approved' | 'rejected',
   approverId?: string,

--- a/src/apis/leaveRequests.api.ts
+++ b/src/apis/leaveRequests.api.ts
@@ -1,4 +1,5 @@
 import type {
+  LeaveApprovals,
   LeaveRequestDTO,
   LeaveRequestFormValue,
 } from '@/types/DTO/leaveRequests.dto';
@@ -29,4 +30,72 @@ export const postLeaveRequests = async (
 
   if (error) throw error;
   return leaveRequestData;
+};
+
+/**
+ * 모든 휴가 신청 목록을 조회합니다.
+ * 휴가 신청과 관련된 상세 정보들을 포함하여 반환합니다.
+ *
+ * @returns 휴가 신청 목록과 관련 정보를 포함한 LeaveApprovals 배열
+ * - 휴가 신청 기본 정보 (신청일, 상태 등)
+ * - leave_type_id: 휴가 유형 정보 (ID, 이름)
+ * - users: 신청자 정보 (ID, 이름, 부서명, 직급명)
+ * - approver: 승인자 정보 (ID, 이름)
+ *
+ * @throws {Error} 데이터베이스 조회 실패 시 Supabase 에러를 던집니다
+ */
+export const getLeaveRequests = async (): Promise<LeaveApprovals> => {
+  const { data: leaveRequestData, error } = await supabase.from(
+    'leave_requests',
+  ).select(`
+      *, 
+      leave_type_id(id, name), 
+      users!leave_requests_user_id_fkey1(
+        id, 
+        name, 
+        departments(name), 
+        positions(name)
+      ),
+      approver:users!leave_requests_approved_by_fkey(
+        id, 
+        name
+      )
+    `);
+
+  if (error) throw error;
+  return leaveRequestData;
+};
+
+/**
+ * 하나 이상의 휴가 신청 상태를 업데이트합니다.
+ * 상태는 'approved' 또는 'rejected' 중 하나로 설정되며, 승인자 ID와 승인 시간을 함께 기록합니다.
+ *
+ * @param requestId - 상태를 업데이트할 휴가 신청 ID 또는 그 배열
+ * @param status - 설정할 휴가 신청 상태 ('approved' | 'rejected')
+ * @param approverId - 승인자 ID (승인자의 고유 식별자), 선택값
+ *
+ * @returns 업데이트된 휴가 신청 정보 배열 (LeaveRequestDTO[])
+ * - id, status, approved_by, approved_at 등 휴가 신청 관련 필드 포함
+ *
+ * @throws {Error} 데이터베이스 업데이트 실패 시 Supabase 에러를 던집니다
+ */
+export const updateLeaveRequestStatus = async (
+  requestId: number | number[],
+  status: 'approved' | 'rejected',
+  approverId?: string,
+): Promise<LeaveRequestDTO[]> => {
+  const ids = Array.isArray(requestId) ? requestId : [requestId];
+
+  const { data, error } = await supabase
+    .from('leave_requests')
+    .update({
+      status,
+      approved_by: approverId,
+      approved_at: new Date().toISOString(),
+    })
+    .in('id', ids)
+    .select();
+
+  if (error) throw error;
+  return data;
 };

--- a/src/components/leaveApproval/LeaveList.tsx
+++ b/src/components/leaveApproval/LeaveList.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/table';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { LeaveRequestDTO } from '@/types/DTO/leaveRequests.dto';
-import { updateLeaveRequestStatus } from '@/apis/leaveRequests.api';
+import { patchLeaveRequestStatus } from '@/apis/leaveRequests.api';
 import { useUserStore } from '@/store/user.store';
 
 const LeaveList = () => {
@@ -41,7 +41,7 @@ const LeaveList = () => {
     requestId: number | number[],
     approverId: string,
   ): Promise<LeaveRequestDTO | LeaveRequestDTO[]> => {
-    return updateLeaveRequestStatus(requestId, 'approved', approverId);
+    return patchLeaveRequestStatus(requestId, 'approved', approverId);
   };
 
   // TODO 반려 누르면 모달창 열려서 반려 사유 작성하기..
@@ -49,7 +49,7 @@ const LeaveList = () => {
     requestId: number | number[],
     approverId: string,
   ): Promise<LeaveRequestDTO | LeaveRequestDTO[]> => {
-    return updateLeaveRequestStatus(requestId, 'rejected', approverId);
+    return patchLeaveRequestStatus(requestId, 'rejected', approverId);
   };
 
   if (isLoading) return <div>로딩중</div>;

--- a/src/components/leaveApproval/LeaveList.tsx
+++ b/src/components/leaveApproval/LeaveList.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  HALF_DAY_TYPE_LABELS,
+  LEAVE_STATUSES_LABELS,
+} from '@/constants/leave.constant';
+import { useGetLeaveRequestsQuery } from '@/hooks/useLeaveRequests';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { LeaveRequestDTO } from '@/types/DTO/leaveRequests.dto';
+import { updateLeaveRequestStatus } from '@/apis/leaveRequests.api';
+import { useUserStore } from '@/store/user.store';
+
+const LeaveList = () => {
+  const user = useUserStore((state) => state.user);
+  const { data: leaveList, isLoading } = useGetLeaveRequestsQuery();
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+
+  const handleCheckboxChange = (id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id],
+    );
+  };
+
+  const handleAllCheck = (checked: boolean) => {
+    if (checked) {
+      setSelectedIds(leaveList ? leaveList.map((leave) => leave.id) : []);
+    } else {
+      setSelectedIds([]);
+    }
+  };
+
+  const approveLeaveRequest = async (
+    requestId: number | number[],
+    approverId: string,
+  ): Promise<LeaveRequestDTO | LeaveRequestDTO[]> => {
+    return updateLeaveRequestStatus(requestId, 'approved', approverId);
+  };
+
+  // TODO 반려 누르면 모달창 열려서 반려 사유 작성하기..
+  const rejectLeaveRequest = async (
+    requestId: number | number[],
+    approverId: string,
+  ): Promise<LeaveRequestDTO | LeaveRequestDTO[]> => {
+    return updateLeaveRequestStatus(requestId, 'rejected', approverId);
+  };
+
+  if (isLoading) return <div>로딩중</div>;
+
+  const columns = [
+    { key: 'select', label: '' },
+    { key: 'id', label: 'No.' },
+    { key: 'name', label: '성명' },
+    { key: 'department', label: '부서' },
+    { key: 'position', label: '직급' },
+    { key: 'leaveType', label: '휴가 유형' },
+    { key: 'startDate', label: '시작 일자' },
+    { key: 'endDate', label: '종료 일자' },
+    { key: 'halfDayType', label: '반차 유형' },
+    { key: 'totalDays', label: '합계' },
+    { key: 'reason', label: '사유' },
+    { key: 'status', label: '진행 상태' },
+    { key: 'requestedAt', label: '신청 일시' },
+    { key: 'approvedBy', label: '승인 담당자' },
+    { key: 'approvedAt', label: '승인 일시' },
+    { key: 'rejectionReason', label: '반려 사유' },
+  ];
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map((column) => (
+              <TableHead key={column.key}>
+                {column.key === 'select' ? (
+                  <Checkbox
+                    checked={
+                      leaveList &&
+                      leaveList.length > 0 &&
+                      selectedIds.length === leaveList.length
+                    }
+                    onCheckedChange={handleAllCheck}
+                  />
+                ) : (
+                  column.label
+                )}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {leaveList?.map((leave, idx) => (
+            <TableRow key={leave.id}>
+              <TableCell>
+                <Checkbox
+                  name="leaveSelect"
+                  id={`leave-checkbox-${leave.id}`}
+                  checked={selectedIds.includes(leave.id)}
+                  onCheckedChange={() => handleCheckboxChange(leave.id)}
+                />
+              </TableCell>
+              <TableCell>{idx + 1}</TableCell>
+              <TableCell>{leave.users.name}</TableCell>
+              <TableCell>{leave.users.departments.name}</TableCell>
+              <TableCell>{leave.users.positions.name}</TableCell>
+              <TableCell>{leave.leave_type_id.name}</TableCell>
+              <TableCell>{leave.start_date}</TableCell>
+              <TableCell>{leave.end_date}</TableCell>
+              <TableCell>
+                {leave.half_day_type
+                  ? HALF_DAY_TYPE_LABELS[leave.half_day_type]
+                  : '-'}
+              </TableCell>
+              <TableCell>{leave.total_days}</TableCell>
+              <TableCell>{leave.reason}</TableCell>
+              <TableCell>{LEAVE_STATUSES_LABELS[leave.status]}</TableCell>
+              <TableCell>{leave.requested_at}</TableCell>
+              <TableCell>{leave.approver?.name}</TableCell>
+              <TableCell>{leave.approved_at}</TableCell>
+              <TableCell>{leave.rejection_reason}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div>
+        <div>
+          <Button
+            type="button"
+            onClick={() => approveLeaveRequest(selectedIds, user.id)}
+          >
+            승인
+          </Button>
+          <Button
+            type="button"
+            onClick={() => rejectLeaveRequest(selectedIds, user.id)}
+          >
+            반려
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LeaveList;

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/constants/leave.constant.ts
+++ b/src/constants/leave.constant.ts
@@ -14,6 +14,13 @@ export const LEAVE_STATUSES = [
   'cancelled',
 ] as const;
 
+export const LEAVE_STATUSES_LABELS = {
+  pending: '대기',
+  approved: '승인',
+  rejected: '반려',
+  cancelled: '취소',
+};
+
 export const LEAVE_TYPE_ID = {
   ANNUAL: 1,
   HALF_DAY: 2,

--- a/src/constants/queryKey.constant.ts
+++ b/src/constants/queryKey.constant.ts
@@ -3,4 +3,5 @@ export const QUERY_KEY = {
   LEAVE_TYPES: 'leave_types',
   DEPARTMENTS: 'departments',
   POSITIONS: 'positions',
+  LEAVE_REQUESTS: 'leave_requests',
 };

--- a/src/hooks/useLeaveRequests.ts
+++ b/src/hooks/useLeaveRequests.ts
@@ -1,0 +1,10 @@
+import { getLeaveRequests } from '@/apis/leaveRequests.api';
+import { QUERY_KEY } from '@/constants/queryKey.constant';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetLeaveRequestsQuery = () => {
+  return useQuery({
+    queryKey: [QUERY_KEY.LEAVE_REQUESTS],
+    queryFn: getLeaveRequests,
+  });
+};

--- a/src/pages/LeaveApprovalPage.tsx
+++ b/src/pages/LeaveApprovalPage.tsx
@@ -1,5 +1,18 @@
+import LeaveList from '@/components/leaveApproval/LeaveList';
+
 const LeaveApprovalPage = () => {
-  return <div>LeaveApprovalPage</div>;
+  return (
+    <section>
+      <h2 className="sr-only">연차 승인</h2>
+      <section>
+        <h3>상세 검색</h3>
+      </section>
+      <section>
+        <h3 className="sr-only">연차 신청 목록</h3>
+        <LeaveList />
+      </section>
+    </section>
+  );
 };
 
 export default LeaveApprovalPage;

--- a/src/types/DTO/leaveRequests.dto.ts
+++ b/src/types/DTO/leaveRequests.dto.ts
@@ -13,12 +13,15 @@ export type LeaveRequestDTO = {
   total_days: number;
   reason: string;
   status: Leave_status;
-  approved_by: string;
-  approved_at: string;
-  rejection_reason: string;
+  approved_by: string | null;
+  approved_at: string | null;
+  rejection_reason: string | null;
   created_at: string;
   updated_at: string;
+  requested_at: string;
 };
+
+export type LeaveRequests = LeaveRequestDTO[];
 
 export type HalfDayType = (typeof HALF_DAY_TYPES)[number];
 
@@ -28,3 +31,24 @@ export type LeaveRequestFormValue = Pick<
   LeaveRequestDTO,
   'leave_type_id' | 'start_date' | 'end_date' | 'half_day_type' | 'reason'
 >;
+
+export type LeaveApprovalDTO = LeaveRequestDTO & {
+  start_date: string;
+  end_date: string;
+  leave_type_id: {
+    id: number;
+    name: string;
+  };
+  users: {
+    id: string;
+    name: string;
+    departments: { name: string };
+    positions: { name: string };
+  };
+  approver: {
+    id: string;
+    name: string;
+  };
+};
+
+export type LeaveApprovals = LeaveApprovalDTO[];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #27 

<br>

## 📝 작업 내용

> 요청이 들어온 연차 목록을 조회하고 승인 처리하는 과정 구현
- **휴가 신청 목록 조회 기능** - 관리자가 모든 직원의 휴가 신청을 한 눈에 확인할 수 있는 테이블 구현
- **일괄 선택 기능** - 체크박스를 통한 개별/전체 선택 기능으로 여러 휴가 신청을 한번에 처리 가능
- **휴가 승인/반려 기능** - 선택된 휴가 신청들에 대한 일괄 승인 및 반려 처리

### 🛠 API 구현
- `getLeaveRequests()` : 휴가 신청 목록 조회 API
  - 신청자 정보, 부서/직급, 휴가 유형, 승인자 정보 등 관련 데이터 조인 조회
- `updateLeaveRequestStatus()` : 휴가 신청 상태 업데이트 API
  - 단일/다중 휴가 신청 상태 변경 지원 (`approved` | `rejected`)
  - 승인자 정보 및 승인 시간 자동 기록

### 📋 UI 컴포넌트
- `LeaveList` 컴포넌트 - 휴가 신청 관리 테이블
  - 16개 컬럼으로 구성된 상세 정보 표시 (성명, 부서, 직급, 휴가유형, 기간, 상태 등)
  - 반차 유형, 승인 담당자, 반려 사유 등 세부 정보 포함
  - 로딩 상태 처리 및 사용자 친화적 인터페이스

### 🏗 타입 정의
  - `LeaveApprovalDTO` - 휴가 승인 관련 데이터 타입 정의
  - `LeaveApprovals` - 휴가 승인 목록 타입 정의
  - 중첩된 관계형 데이터 구조 타입 정의 (사용자, 부서, 직급, 승인자 정보)

<br>

### 📝 TODO
**1. 기능 개선**
- 반려 사유 입력 모달 - 반려 처리 시 반려 사유를 입력받는 모달창 구현
- 에러 처리 및 사용자 피드백 - API 호출 실패 시 토스트 알림 또는 에러 메시지 표시

**2. 코드 리팩토링**
- 컴포넌트 구조 개선 
  - `LeaveList` → `LeaveTable`로 네이밍 변경
  - `LeaveListItem` 컴포넌트 분리를 통한 개별 행 렌더링 책임 분리
- 상태 관리 개선
  - 휴가 상태 업데이트를 useMutation 훅으로 리팩토링
  - 로딩 상태 및 에러 처리 개선
  - 성공 시 자동 캐시 무효화를 통한 실시간 목록 업데이트

**3. UX 개선**
- 버튼 상태 관리 - 선택된 항목이 없을 때 승인/반려 버튼 비활성화
- 로딩 인디케이터 - 승인/반려 처리 중 버튼 텍스트 변경 (처리 중...)
- 선택 상태 시각화 - 선택된 행에 대한 시각적 피드백 개선

<br>

## 🖼 스크린샷
<img width="1868" height="463" alt="image" src="https://github.com/user-attachments/assets/3d6ca916-48a2-4582-8cb4-8a2fc9a32bff" />

<br>

## 💬리뷰 요구사항

> 현재는 기본 기능 구현에 집중했으며, 위 TODO 항목들을 통해 점진적으로 개선해 나갈 예정입니다. 검토 후 의견 부탁드립니다! 